### PR TITLE
Wrong ISO 3166-1 Numeric Code for Iceland causing payment issue.

### DIFF
--- a/paymentsense.php
+++ b/paymentsense.php
@@ -651,7 +651,7 @@ class Paymentsense extends PaymentModule
         'Faroe Islands' => 234, 'Fiji' => 242, 'Finland' => 246, 'French Guiana' => 254, 'French Polynesia' => 258, 'French Southern Territories' => 260,
         'Gabon' => 266, 'Gambia' => 270, 'Georgia' => 268, 'Ghana' => 288, 'Gibraltar' => 292, 'Greece' => 300, 'Greenland' => 304, 'Grenada' => 308,
         'Guadaloupe' => 312, 'Guam' => 316, 'Guatemala' => 320, 'Guernsey' => 831, 'Guinea' => 324, 'Guinea-Bissau' => 624, 'Guyana' => 328, 'Haiti' => 332,
-        'Heard Island and McDonald Islands' => 334, 'Honduras' => 340, 'Hong Kong' => 344, 'Hungary' => 348, 'Iceland' => 352, 'Indonesia' => 360,
+        'Heard Island and McDonald Islands' => 334, 'Honduras' => 340, 'Hong Kong' => 344, 'Hungary' => 348, 'Iceland' => 352, 'India' => 356, 'Indonesia' => 360,
         'Iran' => 364, 'Iraq' => 368, 'Ireland' => 372, 'Isle of Man' => 833, 'Israel' => 376, 'Italy' => 380, 'Jamaica' => 388, 'Japan' => 392,
         'Jersey' => 832, 'Jordan' => 400, 'Kazakhstan' => 398, 'Kenya' => 404, 'Kiribati' => 296, 'South Korea' => 410, 'North Korea' => 408, 'Kuwait' => 414,
         'Kyrgyzstan' => 417, 'Lao' => 418, 'Latvia' => 428, 'Lebanon' => 422, 'Lesotho' => 426, 'Liberia' => 430, 'Libyan Arab Jamahiriya' => 434,

--- a/paymentsense.php
+++ b/paymentsense.php
@@ -651,7 +651,7 @@ class Paymentsense extends PaymentModule
         'Faroe Islands' => 234, 'Fiji' => 242, 'Finland' => 246, 'French Guiana' => 254, 'French Polynesia' => 258, 'French Southern Territories' => 260,
         'Gabon' => 266, 'Gambia' => 270, 'Georgia' => 268, 'Ghana' => 288, 'Gibraltar' => 292, 'Greece' => 300, 'Greenland' => 304, 'Grenada' => 308,
         'Guadaloupe' => 312, 'Guam' => 316, 'Guatemala' => 320, 'Guernsey' => 831, 'Guinea' => 324, 'Guinea-Bissau' => 624, 'Guyana' => 328, 'Haiti' => 332,
-        'Heard Island and McDonald Islands' => 334, 'Honduras' => 340, 'Hong Kong' => 344, 'Hungary' => 348, 'India' => 352, 'Indonesia' => 360,
+        'Heard Island and McDonald Islands' => 334, 'Honduras' => 340, 'Hong Kong' => 344, 'Hungary' => 348, 'Iceland' => 352, 'Indonesia' => 360,
         'Iran' => 364, 'Iraq' => 368, 'Ireland' => 372, 'Isle of Man' => 833, 'Israel' => 376, 'Italy' => 380, 'Jamaica' => 388, 'Japan' => 392,
         'Jersey' => 832, 'Jordan' => 400, 'Kazakhstan' => 398, 'Kenya' => 404, 'Kiribati' => 296, 'South Korea' => 410, 'North Korea' => 408, 'Kuwait' => 414,
         'Kyrgyzstan' => 417, 'Lao' => 418, 'Latvia' => 428, 'Lebanon' => 422, 'Lesotho' => 426, 'Liberia' => 430, 'Libyan Arab Jamahiriya' => 434,


### PR DESCRIPTION
As stated in the title, Having issues with Icelandic customers due to wrong iso code being used in paymentsense.php file.